### PR TITLE
Remove passwordless ssh configuration

### DIFF
--- a/openflight-slurm-standalone/prepare.sh
+++ b/openflight-slurm-standalone/prepare.sh
@@ -12,22 +12,6 @@ fi
 
 dnf install -y munge munge-libs perl-Switch numactl flight-slurm flight-slurm-devel flight-slurm-perlapi flight-slurm-torque flight-slurm-slurmd flight-slurm-example-configs flight-slurm-libpmi flight-slurm-slurmctld
 
-# Passwordless SSH for Root
-KEYNAME="/root/.ssh/id_flightprofile"
-if [ ! -f $KEYNAME ]
-then
-  ssh-keygen -t rsa -N '' -f $KEYNAME
-fi
-if ! grep -q "$(cat $KEYNAME.pub)" /root/.ssh/authorized_keys
-then
-  cat $KEYNAME.pub >> /root/.ssh/authorized_keys
-fi
-if ! grep -q "IdentityFile $KEYNAME" /root/.ssh/config
-then
-  echo "Host *" >> /root/.ssh/config
-  echo "  IdentityFile $KEYNAME" >> /root/.ssh/config
-fi
-
 if [ ! -d openflight-slurm-standalone/.git ]
 then
   git clone https://github.com/openflighthpc/openflight-slurm-standalone


### PR DESCRIPTION
Configuring passwordless SSH for the root user is outside of the scope of the flight profile tool, ultimately this is something that should be setup by the admin of the system using it.

In the case of our packaged image, this is something that flight starter handles - making this part of the prepare script redundant. 

**This is dependent on the merge+release of the[ fixes to flight-starter](https://github.com/openflighthpc/flight-starter/pull/13) to allow for root passwordless ssh to be enabled via config settings**