### PR TITLE
Add Pre Hook for SLURM Multinode

### DIFF
--- a/openflight-slurm-multinode/identities/compute.yaml
+++ b/openflight-slurm-multinode/identities/compute.yaml
@@ -2,5 +2,6 @@ name: compute
 description: Configure a Compute Node of a Multinode SLURM Research Environment
 group_name: compute
 commands: 
+- pre: "$RUN_ENV/openflight-slurm-multinode/flight-profile-pre.sh"
 - main: "$RUN_ENV/openflight-slurm-multinode/flight-profile-main.sh"
 - post: "$RUN_ENV/openflight-slurm-multinode/flight-profile-post.sh"

--- a/openflight-slurm-multinode/identities/login.yaml
+++ b/openflight-slurm-multinode/identities/login.yaml
@@ -2,5 +2,6 @@ name: login
 description: Configure the Login Node of a Multinode SLURM Research Environment
 group_name: login
 commands:
+- pre: "$RUN_ENV/openflight-slurm-multinode/flight-profile-pre.sh"
 - main: "$RUN_ENV/openflight-slurm-multinode/flight-profile-main.sh"
 - post: "$RUN_ENV/openflight-slurm-multinode/flight-profile-post.sh"


### PR DESCRIPTION
This includes the pre-hook script provided in the openflight-slurm-multinode playbook in the stages of the related Flight Profile Type 