### PR TITLE
Remove Hunter Question in Favour of Var Hand-Through from Profile

### DIFF
--- a/openflight-kubernetes-multinode/metadata.yaml
+++ b/openflight-kubernetes-multinode/metadata.yaml
@@ -47,11 +47,3 @@ questions:
     default: '192.168.0.0/16'
     validation:
       type: string
-  - id: hunter_hosts
-    env: HUNTER_HOSTS
-    text: 'Create hosts entries from Flight Hunter data?'
-    default: true
-    validation:
-      type: string
-      format: "^(?i)(true|false)$"
-      message: "Must be either true or false"

--- a/openflight-slurm-multinode/metadata.yaml
+++ b/openflight-slurm-multinode/metadata.yaml
@@ -47,11 +47,3 @@ questions:
     default: '10.10.0.0/16'
     validation:
       type: string
-  - id: hunter_hosts
-    env: HUNTER_HOSTS
-    text: 'Create hosts entries from Flight Hunter data?'
-    default: true
-    validation:
-      type: string
-      format: "^(?i)(true|false)$"
-      message: "Must be either true or false"


### PR DESCRIPTION
Update multinode profile types to support hunter variable being exposed by https://github.com/openflighthpc/flight-profile/pull/66

This will need to be merged once the previously mentioned PR has been fixed and merged 