### PR TITLE
Add smart default commands

### DIFF
--- a/openflight-jupyter-standalone/metadata.yaml
+++ b/openflight-jupyter-standalone/metadata.yaml
@@ -27,5 +27,6 @@ questions:
   - id: access_host
     env: ACCESS_HOST
     text: 'IP or FQDN for Web Access:'
+    default_smart: "curl -s ifconfig.me"
     validation:
       type: string

--- a/openflight-kubernetes-multinode/metadata.yaml
+++ b/openflight-kubernetes-multinode/metadata.yaml
@@ -28,17 +28,20 @@ questions:
     env: NFS_SERVER
     text: 'NFS server (hostname or flight-hunter label):'
     default: 'login1'
+    default_smart: "HUNT=$(/opt/flight/bin/flight hunter list --plain |grep $(hostname -f) |awk '{print $5}') HOST=$(hostname -s); echo ${HUNT:-$HOST}"
     validation:
       type: string
   - id: access_host
     env: ACCESS_HOST
     text: 'IP or FQDN for Web Access:'
+    default_smart: "curl -s ifconfig.me"
     validation:
       type: string
   - id: compute_ip_range
     env: COMPUTE_IP_RANGE
     text: 'IP Range of Compute Nodes:'
     default: '10.10.0.0/16'
+    default_smart: "ipcalc $(/usr/sbin/ip addr show $(/usr/sbin/ip -o -4 route show to default |awk '{print $5}') |grep 'inet ' |sed 's.*inet //g;s/ brd.*//g') |grep '^Network:' |awk '{print $2}'"
     validation:
       type: string
   - id: pod_ip_range

--- a/openflight-kubernetes-multinode/metadata.yaml
+++ b/openflight-kubernetes-multinode/metadata.yaml
@@ -41,7 +41,7 @@ questions:
     env: COMPUTE_IP_RANGE
     text: 'IP Range of Compute Nodes:'
     default: '10.10.0.0/16'
-    default_smart: "ipcalc $(/usr/sbin/ip addr show $(/usr/sbin/ip -o -4 route show to default |awk '{print $5}') |grep 'inet ' |sed 's.*inet //g;s/ brd.*//g') |grep '^Network:' |awk '{print $2}'"
+    default_smart: "ipcalc $(/usr/sbin/ip addr show $(/usr/sbin/ip -o -4 route show to default |awk '{print $5}') |grep 'inet ' |sed 's/.*inet //g;s/ brd.*//g') |grep '^Network:' |awk '{print $2}'"
     validation:
       type: string
   - id: pod_ip_range

--- a/openflight-slurm-multinode/metadata.yaml
+++ b/openflight-slurm-multinode/metadata.yaml
@@ -16,12 +16,14 @@ questions:
     env: NFS_SERVER
     text: 'NFS server (hostname or flight-hunter label):'
     default: 'login1'
+    default_smart: "HUNT=$(/opt/flight/bin/flight hunter list --plain |grep $(hostname -f) |awk '{print $5}') HOST=$(hostname -s); echo ${HUNT:-$HOST}"
     validation:
       type: string
   - id: slurm_server
     env: SLURM_SERVER
     text: 'SLURM server (hostname or flight-hunter label):'
     default: 'login1'
+    default_smart: "HUNT=$(/opt/flight/bin/flight hunter list --plain |grep $(hostname -f) |awk '{print $5}') HOST=$(hostname -s); echo ${HUNT:-$HOST}"
     validation:
       type: string
   - id: default_username
@@ -39,11 +41,13 @@ questions:
   - id: access_host
     env: ACCESS_HOST
     text: 'IP or FQDN for Web Access:'
+    default_smart: "curl -s ifconfig.me"
     validation:
       type: string
   - id: compute_ip_range
     env: COMPUTE_IP_RANGE
     text: 'IP Range of Compute Nodes:'
     default: '10.10.0.0/16'
+    default_smart: "ipcalc $(/usr/sbin/ip addr show $(/usr/sbin/ip -o -4 route show to default |awk '{print $5}') |grep 'inet ' |sed 's/.*inet //g;s/ brd.*//g') |grep '^Network:' |awk '{print $2}'"
     validation:
       type: string

--- a/openflight-slurm-standalone/metadata.yaml
+++ b/openflight-slurm-standalone/metadata.yaml
@@ -27,5 +27,6 @@ questions:
   - id: access_host
     env: ACCESS_HOST
     text: 'IP or FQDN for Web Access:'
+    default_smart: "curl -s ifconfig.me"
     validation:
       type: string


### PR DESCRIPTION
Adds smart default commands to attempt to calculate some runtime information for `configure`. This should allow nodes to identify their own labels in some cases.

This will need some further testing/verifying beyond my initial testing that didn't seem to break. 