### PR TITLE
Reformat existing commands for new type

### DIFF
--- a/openflight-jupyter-standalone/metadata.yaml
+++ b/openflight-jupyter-standalone/metadata.yaml
@@ -27,6 +27,7 @@ questions:
   - id: access_host
     env: ACCESS_HOST
     text: 'IP or FQDN for Web Access:'
-    default_smart: "AWS=$(curl --connect-timeout 1 -s --fail http://169.254.169.254/latest/meta-data/public-ipv4) AZURE=$(curl --connect-timeout 1 -s --fail -H Metadata:true http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0?api-version=2021-12-13 |sed 's/.*publicIpAddress\":\"//g;s/\".*//g') CLOUD=${AWS:-$AZURE} ; echo ${CLOUD:-$(curl -s ifconfig.me)}"
+    default_smart:
+      - "AWS=$(curl --connect-timeout 1 -s --fail http://169.254.169.254/latest/meta-data/public-ipv4) AZURE=$(curl --connect-timeout 1 -s --fail -H Metadata:true http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0?api-version=2021-12-13 |sed 's/.*publicIpAddress\":\"//g;s/\".*//g') CLOUD=${AWS:-$AZURE} ; echo ${CLOUD:-$(curl -s ifconfig.me)}"
     validation:
       type: string

--- a/openflight-kubernetes-multinode/metadata.yaml
+++ b/openflight-kubernetes-multinode/metadata.yaml
@@ -28,20 +28,23 @@ questions:
     env: NFS_SERVER
     text: 'NFS server (hostname or flight-hunter label):'
     default: 'login1'
-    default_smart: "HUNT=$(/opt/flight/bin/flight hunter list --plain |grep $(hostname -f) |awk '{print $5}') HOST=$(hostname -s); echo ${HUNT:-$HOST}"
+    default_smart:
+      - "HUNT=$(/opt/flight/bin/flight hunter list --plain |grep $(hostname -f) |awk '{print $5}') HOST=$(hostname -s); echo ${HUNT:-$HOST}"
     validation:
       type: string
   - id: access_host
     env: ACCESS_HOST
     text: 'IP or FQDN for Web Access:'
-    default_smart: "AWS=$(curl --connect-timeout 1 -s --fail http://169.254.169.254/latest/meta-data/public-ipv4) AZURE=$(curl --connect-timeout 1 -s --fail -H Metadata:true http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0?api-version=2021-12-13 |sed 's/.*publicIpAddress\":\"//g;s/\".*//g') CLOUD=${AWS:-$AZURE} ; echo ${CLOUD:-$(curl -s ifconfig.me)}"
+    default_smart:
+      - "AWS=$(curl --connect-timeout 1 -s --fail http://169.254.169.254/latest/meta-data/public-ipv4) AZURE=$(curl --connect-timeout 1 -s --fail -H Metadata:true http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0?api-version=2021-12-13 |sed 's/.*publicIpAddress\":\"//g;s/\".*//g') CLOUD=${AWS:-$AZURE} ; echo ${CLOUD:-$(curl -s ifconfig.me)}"
     validation:
       type: string
   - id: compute_ip_range
     env: COMPUTE_IP_RANGE
     text: 'IP Range of Compute Nodes:'
     default: '10.10.0.0/16'
-    default_smart: "ipcalc $(/usr/sbin/ip addr show $(/usr/sbin/ip -o -4 route show to default |awk '{print $5}') |grep 'inet ' |sed 's/.*inet //g;s/ brd.*//g') |grep '^Network:' |awk '{print $2}'"
+    default_smart:
+      - "ipcalc $(/usr/sbin/ip addr show $(/usr/sbin/ip -o -4 route show to default |awk '{print $5}') |grep 'inet ' |sed 's/.*inet //g;s/ brd.*//g') |grep '^Network:' |awk '{print $2}'"
     validation:
       type: string
   - id: pod_ip_range

--- a/openflight-slurm-multinode/metadata.yaml
+++ b/openflight-slurm-multinode/metadata.yaml
@@ -16,14 +16,16 @@ questions:
     env: NFS_SERVER
     text: 'NFS server (hostname or flight-hunter label):'
     default: 'login1'
-    default_smart: "HUNT=$(/opt/flight/bin/flight hunter list --plain |grep $(hostname -f) |awk '{print $5}') HOST=$(hostname -s); echo ${HUNT:-$HOST}"
+    default_smart:
+      - "HUNT=$(/opt/flight/bin/flight hunter list --plain |grep $(hostname -f) |awk '{print $5}') HOST=$(hostname -s); echo ${HUNT:-$HOST}"
     validation:
       type: string
   - id: slurm_server
     env: SLURM_SERVER
     text: 'SLURM server (hostname or flight-hunter label):'
     default: 'login1'
-    default_smart: "HUNT=$(/opt/flight/bin/flight hunter list --plain |grep $(hostname -f) |awk '{print $5}') HOST=$(hostname -s); echo ${HUNT:-$HOST}"
+    default_smart:
+      - "HUNT=$(/opt/flight/bin/flight hunter list --plain |grep $(hostname -f) |awk '{print $5}') HOST=$(hostname -s); echo ${HUNT:-$HOST}"
     validation:
       type: string
   - id: default_username
@@ -41,13 +43,15 @@ questions:
   - id: access_host
     env: ACCESS_HOST
     text: 'IP or FQDN for Web Access:'
-    default_smart: "AWS=$(curl --connect-timeout 1 -s --fail http://169.254.169.254/latest/meta-data/public-ipv4) AZURE=$(curl --connect-timeout 1 -s --fail -H Metadata:true http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0?api-version=2021-12-13 |sed 's/.*publicIpAddress\":\"//g;s/\".*//g') CLOUD=${AWS:-$AZURE} ; echo ${CLOUD:-$(curl -s ifconfig.me)}"
+    default_smart:
+      - "AWS=$(curl --connect-timeout 1 -s --fail http://169.254.169.254/latest/meta-data/public-ipv4) AZURE=$(curl --connect-timeout 1 -s --fail -H Metadata:true http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0?api-version=2021-12-13 |sed 's/.*publicIpAddress\":\"//g;s/\".*//g') CLOUD=${AWS:-$AZURE} ; echo ${CLOUD:-$(curl -s ifconfig.me)}"
     validation:
       type: string
   - id: compute_ip_range
     env: COMPUTE_IP_RANGE
     text: 'IP Range of Compute Nodes:'
     default: '10.10.0.0/16'
-    default_smart: "ipcalc $(/usr/sbin/ip addr show $(/usr/sbin/ip -o -4 route show to default |awk '{print $5}') |grep 'inet ' |sed 's/.*inet //g;s/ brd.*//g') |grep '^Network:' |awk '{print $2}'"
+    default_smart:
+      - "ipcalc $(/usr/sbin/ip addr show $(/usr/sbin/ip -o -4 route show to default |awk '{print $5}') |grep 'inet ' |sed 's/.*inet //g;s/ brd.*//g') |grep '^Network:' |awk '{print $2}'"
     validation:
       type: string

--- a/openflight-slurm-standalone/metadata.yaml
+++ b/openflight-slurm-standalone/metadata.yaml
@@ -27,6 +27,7 @@ questions:
   - id: access_host
     env: ACCESS_HOST
     text: 'IP or FQDN for Web Access:'
-    default_smart: "AWS=$(curl --connect-timeout 1 -s --fail http://169.254.169.254/latest/meta-data/public-ipv4) AZURE=$(curl --connect-timeout 1 -s --fail -H Metadata:true http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0?api-version=2021-12-13 |sed 's/.*publicIpAddress\":\"//g;s/\".*//g') CLOUD=${AWS:-$AZURE} ; echo ${CLOUD:-$(curl -s ifconfig.me)}"
+    default_smart:
+      - "AWS=$(curl --connect-timeout 1 -s --fail http://169.254.169.254/latest/meta-data/public-ipv4) AZURE=$(curl --connect-timeout 1 -s --fail -H Metadata:true http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0?api-version=2021-12-13 |sed 's/.*publicIpAddress\":\"//g;s/\".*//g') CLOUD=${AWS:-$AZURE} ; echo ${CLOUD:-$(curl -s ifconfig.me)}"
     validation:
       type: string


### PR DESCRIPTION
This change sets the `default_smart` fields to be arrays instead of strings, ahead of the latest changes to how Profile handles the commands