### PR TITLE
Exit prepare scripts when error raised

### DIFF
--- a/openflight-jupyter-standalone/prepare.sh
+++ b/openflight-jupyter-standalone/prepare.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if ! command -v ansible &> /dev/null
 then
   dnf install -y ansible

--- a/openflight-kubernetes-multinode/prepare.sh
+++ b/openflight-kubernetes-multinode/prepare.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if ! command -v ansible &> /dev/null
 then
   dnf install -y ansible

--- a/openflight-slurm-multinode/prepare.sh
+++ b/openflight-slurm-multinode/prepare.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if ! command -v ansible &> /dev/null
 then
   dnf install -y ansible

--- a/openflight-slurm-standalone/prepare.sh
+++ b/openflight-slurm-standalone/prepare.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if ! command -v ansible &> /dev/null
 then
   dnf install -y ansible


### PR DESCRIPTION
This small PR causes each type's `prepare` script to exit whenever an error occurs in the script. This allows Profile to properly detect that the preparation has failed. Previously the scripts would only exit with error codes if the last command in the file exited with an error.