### PR TITLE
Various fixes for EL9

### DIFF
--- a/openflight-jupyter-standalone/prepare.sh
+++ b/openflight-jupyter-standalone/prepare.sh
@@ -10,7 +10,7 @@ then
   dnf install -y git
 fi
 
-dnf install -y python39
+dnf install -y python39 python3-pip
 # unsure if the -y option works with pip install
 pip3.9 install jupyterlab 
 

--- a/openflight-slurm-multinode/prepare.sh
+++ b/openflight-slurm-multinode/prepare.sh
@@ -15,9 +15,13 @@ dnf install -y munge munge-libs perl-Switch numactl flight-slurm flight-slurm-de
 dnf install -y nfs-utils
 
 # IPA
-dnf module reset -y idm
-dnf module enable -y idm:DL1
-dnf module install -y idm:DL1/dns
+if [[ $CENTOS_VER == 0 ]] ; then 
+    dnf -y install freeipa-server freeipa-server-dns freeipa-client
+else
+    dnf module reset -y idm
+    dnf module enable -y idm:DL1
+    dnf module install -y idm:DL1/dns
+fi
 
 # ensure v6.6.0 or above installed for append option in ipa_hostgroup
 ansible-galaxy collection install 'community.general:>6.6.0' --upgrade

--- a/openflight-slurm-multinode/prepare.sh
+++ b/openflight-slurm-multinode/prepare.sh
@@ -15,7 +15,8 @@ dnf install -y munge munge-libs perl-Switch numactl flight-slurm flight-slurm-de
 dnf install -y nfs-utils
 
 # IPA
-if [[ $CENTOS_VER == 0 ]] ; then 
+CENTOS_VER=$(rpm --eval '%{centos_ver}')
+if [[ $CENTOS_VER == 9 ]] ; then 
     dnf -y install freeipa-server freeipa-server-dns freeipa-client
 else
     dnf module reset -y idm


### PR DESCRIPTION
- Explicitly install pip for Jupyter Lab (not pulled in as part of python3 anymore)
- Handle package installation differences between 8 and 9 for IPA in openflight-slurm-multinode